### PR TITLE
refactor: separate nginx log group from app logs

### DIFF
--- a/container.tf
+++ b/container.tf
@@ -117,7 +117,7 @@ module "container_definition_nginx" { // Nginx task
     logDriver = "awslogs"
     options = {
       awslogs-region        = data.aws_region.current.name
-      awslogs-group         = aws_cloudwatch_log_group.application_logs.name
+      awslogs-group         = aws_cloudwatch_log_group.nginx_logs[0].name
       awslogs-stream-prefix = "ecs"
     }
   }

--- a/logs.tf
+++ b/logs.tf
@@ -4,6 +4,18 @@ resource "aws_cloudwatch_log_group" "application_logs" {
   tags              = var.tags
 }
 
+resource "aws_cloudwatch_log_group" "nginx_logs" {
+  count = var.create_alb_resources && var.create_nginx ? 1 : 0
+
+  name              = "${local.name}-nginx"
+  retention_in_days = var.log_retention
+  tags              = var.tags
+}
+
 output "cloudwatch_log_group_arn" {
   value = aws_cloudwatch_log_group.application_logs.arn
+}
+
+output "cloudwatch_log_group_name" {
+  value = aws_cloudwatch_log_group.application_logs.name
 }


### PR DESCRIPTION
This makes it easier to process logs separately.